### PR TITLE
Workaround for #9 - goimports on save hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ AnacondaGO adds autocompletion, linting and IDE features for Golang to your Subl
   * [Explore Packages](#explore-packages)
   * [Symbol under the cursor analysis and navigation](#symbol-under-the-cursor-analysis-and-navigation)
   * [Show Documentation for symbol under cursor](#show-documentation-for-symbol-under-cursor)
+* [Known Issues](#known-issues)
 * [License](#license)
 
 ## NOTICE!

--- a/README.md
+++ b/README.md
@@ -540,6 +540,28 @@ AnacondaGO offers a simple to use installed packages documentation explorer that
 
 Open the *Command Palette* and use the command **AnacondaGO: Show Packages Documentation**.
 
+## Known Issues
+
+### [Issue #9](https://github.com/DamnWidget/anaconda_go/issues/9): Problems with saving file when linting and gofmt on save are both enabled
+
+Because of an issue with the async nature of the anaconda_go commands, you may see an issue when saving your changes to a Go source file. Both the linting and gofmt commands try to run and end up leaving the file dirty or reverting changes you had just made. A workaround is to enable an included pre-save listener, which will invoke the goimports command in a sychronous way.
+
+#### Usage
+
+First make sure to install the GoImports SublimeText3 package: https://packagecontrol.io/packages/GoImports
+
+In your Anaconda_GO settings, disable the auto format option:
+
+```json
+    "anaconda_go_auto_format": false
+```
+
+In either your general preferences or your project settings, enable the goimports save hook:
+
+```json
+    "goimports_on_save": true
+```
+
 ## License
 This program is distributed under the terms of the GNU GPL v3. See the [LICENSE][license] file for more details.
 

--- a/listeners/__init__.py
+++ b/listeners/__init__.py
@@ -6,9 +6,10 @@
 from anaconda_go.listeners.linting import BackgroundLinter
 from anaconda_go.listeners.autocompletion import GoCompletionEventListener
 from anaconda_go.listeners.autoformat import AnacondaGoAutoFormatEventListener
-
+from anaconda_go.listeners.goimports_and_save import GoImportsOnSave
 
 __all__ = [
     'BackgroundLinter', 'GoCompletionEventListener',
-    'AnacondaGoAutoFormatEventListener'
+    'AnacondaGoAutoFormatEventListener',
+    'GoImportsOnSave',
 ]

--- a/listeners/goimports_and_save.py
+++ b/listeners/goimports_and_save.py
@@ -1,0 +1,35 @@
+"""
+Workaround for https://github.com/DamnWidget/anaconda_go/issues/9
+"""
+import re
+import sublime, sublime_plugin
+
+class GoImportsOnSave(sublime_plugin.EventListener):
+    """
+    Run goimports against Go language syntax documents, on save.
+    For use in combination with the GoImports SublimeText plugin package.
+    
+    Enable 'goimports_on_save' in your project or application settings.
+    """
+    # Supported syntax
+    _SYNTAX = frozenset(["go"])
+    _RX_SOURCE = re.compile(r'source\.(\S+)')
+
+    def on_pre_save(self, view):
+        enabled = view.settings().get("goimports_on_save", False)
+        if not enabled:
+            return
+
+        scope = view.scope_name(0)
+        match = self._RX_SOURCE.match(scope)
+        if not match:
+            return
+
+        syntax = match.group(1)
+        if syntax.lower() not in self._SYNTAX:
+            return
+
+        try:
+            view.run_command("go_imports")
+        except Exception as e:
+            pass


### PR DESCRIPTION
Refs #9 

Adds a pre-save hook to run goimports. Must be enabled as a workaround.