### PR TITLE
Add possibility to use gofmt and provide formatter args

### DIFF
--- a/Anaconda_GO.sublime-settings
+++ b/Anaconda_GO.sublime-settings
@@ -95,6 +95,18 @@
 	// Auto format file on save
 	"anaconda_go_auto_format": true,
 
+	// Use goimports to format files
+	"anaconda_go_format_with_goimports": true,
+
+	// Arguments for the goimports command
+	"anaconda_go_goimports_args": [],
+
+	// Use gofmt to format files
+	"anaconda_go_format_with_gofmt": false,
+
+	// Arguments for the gofmt command
+	"anaconda_go_gofmt_args": ["-s"],
+
 	// Set this to true if you want to force go doc to return private methods documentation
 	// Note: go doc is used if the go version is lower than 1.6 only if not forced except
 	// when the Packages Documentation feature is used that go doc is always used


### PR DESCRIPTION
Apparently, goimports is not considered a drop-in replacement for gofmt anymore. I'm still waiting for these tools to be merged in a single format-everything tool.

I like to use both formatters when saving because gofmt still has some functionalities that goimports doesn't have (enforcing 8-space indentation, simplifying redundant statements)

This PR gives the possibility to use either both formatters, or only one of them. Gofmt is disabled by default so that existing users won't be surprised by different formatting or added overhead.