### PR TITLE
Update gocode and bug fix for Windows OS

### DIFF
--- a/commands/format.py
+++ b/commands/format.py
@@ -20,6 +20,12 @@ class AnacondaGoFormatSync(sublime_plugin.TextCommand):
     def get_binary(self, name):
         """Get absolute path of a go binary
         """
+        
+        # Add .exe to file name if os is Windows NT
+        if os.name == 'nt':
+            _, file_ext = os.path.splitext(name)
+            if file_ext != ".exe":
+                name = name + ".exe"
 
         if go.GOBIN:
             binary_path = os.path.join(go.GOBIN, name)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -22,7 +22,7 @@ class GoWrapper:
         'golang.org/x/tools/cmd/guru',
         'github.com/fatih/motion',
         'github.com/josharian/impl',
-        'github.com/nsf/gocode',
+        'github.com/stamblerre/gocode',
         'github.com/zmb3/gogetdoc',
         'gopkg.in/alecthomas/gometalinter.v1'
     ]

--- a/plugin/handlers_go/anagonda/context/autocomplete.py
+++ b/plugin/handlers_go/anagonda/context/autocomplete.py
@@ -12,7 +12,7 @@ from process import spawn
 from .error import AnaGondaError
 from .base import AnaGondaContext
 
-_go_get = 'github.com/nsf/gocode'
+_go_get = 'github.com/stamblerre/gocode'
 
 
 class AutoCompleteError(AnaGondaError):

--- a/plugin/handlers_go/anagonda/context/base.py
+++ b/plugin/handlers_go/anagonda/context/base.py
@@ -81,6 +81,12 @@ class AnaGondaContext(object):
     def get_binary(self, binary):
         """Get a binary from the GOBIN/GOPATH
         """
+        
+        # Add .exe to file name if os is Windows NT
+        if os.name == 'nt':
+            _, file_ext = os.path.splitext(binary)
+            if file_ext != ".exe":
+                binary = binary + ".exe"
 
         if self.env.get('GOBIN') is not None:
             binary_path = os.path.join(self.env['GOBIN'], binary)


### PR DESCRIPTION
1. Update new version of gocode
    Change from 
        github.com/nsf/gocode 
    to 
        github.com/stamblerre/gocode

2. Add .exe to executable file name if os is Windows NT
    When use anaconda_go on Windows, it cannot get executable file name "gocode" as on Linux. So we must add ".exe" to the filename if os == 'nt'
